### PR TITLE
Diff shown in abapGit for zdemo_excel51 after pull

### DIFF
--- a/src/zdemo_excel51.prog.xml
+++ b/src/zdemo_excel51.prog.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>


### PR DESCRIPTION
The issue in abapGit was about the file `zdemo_excel51.prog.xml` showing a difference ("Diff" button). The difference was about the first line `<?xml version="1.0" encoding="utf-8"?>` but nothing was visible. It's an abapGit issue. Maybe the file was generated with an old abapGit version, which used to generate either a wrong BOM or a wrong Line Break. Using the latest abapGit version seems to fix the issue.