### PR TITLE
Fix zdemo_excel_checker XML loose comparison, etc.

### DIFF
--- a/src/zdemo_excel_checker.prog.abap
+++ b/src/zdemo_excel_checker.prog.abap
@@ -2868,7 +2868,8 @@ CLASS lcl_app IMPLEMENTATION.
         OTHERS              = 3.
 
     " The empty SELECT-OPTIONS contain an empty line which is to be skipped.
-    DELETE lt_sel_255 WHERE     sign   IS INITIAL
+    DELETE lt_sel_255 WHERE     kind    = 'S'
+                            AND sign   IS INITIAL
                             AND option IS INITIAL
                             AND low    IS INITIAL
                             AND high   IS INITIAL.

--- a/src/zdemo_excel_checker.prog.xml
+++ b/src/zdemo_excel_checker.prog.xml
@@ -28,6 +28,12 @@
      <ENTRY>Folder path (write demo files)</ENTRY>
      <LENGTH>38</LENGTH>
     </item>
+    <item>
+     <ID>S</ID>
+     <KEY>S_PROG</KEY>
+     <ENTRY>Demo program</ENTRY>
+     <LENGTH>20</LENGTH>
+    </item>
    </TPOOL>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
Fix #75 (zdemo_excel_checker complains about missing zcl_excel_xml)
+ enhancement to test few demo programs instead of all
+ fix bug Execute button leaves the program