### PR TITLE
Make zdemo_excel32 work always the same

### DIFF
--- a/src/zdemo_excel32.prog.abap
+++ b/src/zdemo_excel32.prog.abap
@@ -146,11 +146,18 @@ ENDFORM.                    " USER_COMMAND
 * This subroutine is principal demo session
 *--------------------------------------------------------------------*
 FORM export_to_excel_conv RAISING zcx_excel.
-  DATA: lo_converter TYPE REF TO zcl_excel_converter.
+  DATA lo_converter TYPE REF TO zcl_excel_converter.
+  DATA ls_option TYPE zexcel_s_converter_option.
+
+  ls_option-filter           = abap_true.
+  ls_option-subtot           = abap_true.
+  ls_option-hidenc           = abap_true.
+  ls_option-conv_exit_length = abap_true.
 
   CREATE OBJECT lo_converter.
   lo_converter->convert(
     EXPORTING
+      is_option     = ls_option
       io_alv        = lo_salv
       it_table      = gt_sbook
       i_row_int     = 2


### PR DESCRIPTION
To not depend on options set previously.
Problem explained in https://github.com/abap2xlsx/abap2xlsx/issues/1238#issuecomment-2340331969